### PR TITLE
Adjustments for Spring Boot 4.1.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.17.3</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>6.1.0</version>
@@ -99,7 +92,14 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>6.1.19</version>
+        <version>7.0.8</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>3.1.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -118,13 +118,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>tools.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
@@ -181,7 +181,7 @@
                   <enforcers>POM_SECTION_ORDER,DEPENDENCY_MANAGEMENT_ORDER,DEPENDENCY_ORDER,DEPENDENCY_CONFIGURATION,DEPENDENCY_ELEMENT,PLUGIN_MANAGEMENT_ORDER,PLUGIN_CONFIGURATION,PLUGIN_ELEMENT</enforcers>
                 </compound>
                 <requireJavaVersion>
-                  <version>[17,18)</version>
+                  <version>[21,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.9,3.10)</version>

--- a/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapDeserializer.java
+++ b/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapDeserializer.java
@@ -15,21 +15,25 @@
  */
 package com.innoq.spring.cookie.flash.codec.jackson;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.json.JsonMapper;
 import org.springframework.web.servlet.FlashMap;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 final class FlashMapDeserializer extends StdDeserializer<FlashMap> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+        .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+        .build();
 
     public FlashMapDeserializer() {
         super(FlashMap.class);
@@ -37,7 +41,7 @@ final class FlashMapDeserializer extends StdDeserializer<FlashMap> {
 
     @Override
     public FlashMap deserialize(JsonParser p, DeserializationContext ctxt)
-            throws IOException {
+            throws JacksonException {
         final JsonNode root = objectMapper.readTree(p);
         final FlashMap flashMap = new FlashMap();
 
@@ -88,11 +92,11 @@ final class FlashMapDeserializer extends StdDeserializer<FlashMap> {
     }
 
     private void handleTargetRequestPath(FlashMap flashMap, JsonNode node) {
-        if (node == null || !node.isTextual()) {
+        if (node == null || !node.isString()) {
             return;
         }
 
-        final String targetRequestPath = node.asText();
+        final String targetRequestPath = node.stringValue();
         flashMap.setTargetRequestPath(targetRequestPath);
     }
 }

--- a/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapSerializer.java
+++ b/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapSerializer.java
@@ -15,12 +15,12 @@
  */
 package com.innoq.spring.cookie.flash.codec.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
 import org.springframework.web.servlet.FlashMap;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 final class FlashMapSerializer extends StdSerializer<FlashMap> {
@@ -30,13 +30,13 @@ final class FlashMapSerializer extends StdSerializer<FlashMap> {
     }
 
     @Override
-    public void serialize(FlashMap value, JsonGenerator gen, SerializerProvider serializers)
-            throws IOException {
+    public void serialize(FlashMap value, JsonGenerator gen, SerializationContext serializers)
+            throws JacksonException {
         gen.writeStartObject();
-        gen.writeObjectField("attributes", new HashMap<>(value));
-        gen.writeNumberField("expirationTime", value.getExpirationTime());
-        gen.writeObjectField("targetRequestParams", value.getTargetRequestParams());
-        gen.writeStringField("targetRequestPath", value.getTargetRequestPath());
+        gen.writePOJOProperty("attributes", new HashMap<>(value));
+        gen.writeNumberProperty("expirationTime", value.getExpirationTime());
+        gen.writePOJOProperty("targetRequestParams", value.getTargetRequestParams());
+        gen.writeStringProperty("targetRequestPath", value.getTargetRequestPath());
         gen.writeEndObject();
     }
 }

--- a/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/JacksonFlashMapListCodec.java
+++ b/src/main/java/com/innoq/spring/cookie/flash/codec/jackson/JacksonFlashMapListCodec.java
@@ -15,21 +15,21 @@
  */
 package com.innoq.spring.cookie.flash.codec.jackson;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import com.innoq.spring.cookie.flash.FlashMapListCodec;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.FlashMap;
 
-import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
 
 public final class JacksonFlashMapListCodec implements FlashMapListCodec {
 
-    private static TypeReference<List<FlashMap>> FLASH_MAPS_TYPE_REFERENCE =
+    private static final TypeReference<List<FlashMap>> FLASH_MAPS_TYPE_REFERENCE =
         new TypeReference<List<FlashMap>>() {};
 
     private final ObjectMapper mapper;
@@ -54,7 +54,7 @@ public final class JacksonFlashMapListCodec implements FlashMapListCodec {
     private byte[] toJson(List<FlashMap> flashMaps) {
         try {
             return mapper.writeValueAsBytes(flashMaps);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             // TODO: use own exception?
             throw new IllegalArgumentException("Unable to convert flash maps to JSON", e);
         }
@@ -63,7 +63,7 @@ public final class JacksonFlashMapListCodec implements FlashMapListCodec {
     private List<FlashMap> fromJson(byte[] json) {
         try {
             return mapper.readValue(json, FLASH_MAPS_TYPE_REFERENCE);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             // TODO: use own exception?
             throw new IllegalArgumentException("Unable to convert JSON to flash maps", e);
         }
@@ -82,8 +82,7 @@ public final class JacksonFlashMapListCodec implements FlashMapListCodec {
         module.addSerializer(FlashMap.class, new FlashMapSerializer());
         module.addDeserializer(FlashMap.class, new FlashMapDeserializer());
 
-        final ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(module);
+        final ObjectMapper mapper = JsonMapper.builder().addModule(module).build();
 
         return create(mapper);
     }

--- a/src/test/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapDeserializerTest.java
+++ b/src/test/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapDeserializerTest.java
@@ -15,9 +15,10 @@
  */
 package com.innoq.spring.cookie.flash.codec.jackson;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import com.innoq.spring.cookie.flash.codec.jackson.FlashMapDeserializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.FlashMap;
@@ -31,9 +32,9 @@ import static org.assertj.core.api.Assertions.entry;
 
 class FlashMapDeserializerTest {
 
-    ObjectMapper sut = new ObjectMapper()
-        .registerModule(
-            new SimpleModule().addDeserializer(FlashMap.class, new FlashMapDeserializer()));
+    ObjectMapper sut = JsonMapper.builder()
+        .addModule(new SimpleModule().addDeserializer(FlashMap.class, new FlashMapDeserializer()))
+        .build();
 
     @Test
     void empty_flash_map_is_deserialized() throws Exception {

--- a/src/test/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapSerializerTest.java
+++ b/src/test/java/com/innoq/spring/cookie/flash/codec/jackson/FlashMapSerializerTest.java
@@ -15,8 +15,9 @@
  */
 package com.innoq.spring.cookie.flash.codec.jackson;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
 import com.innoq.spring.cookie.flash.codec.jackson.FlashMapSerializer;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.FlashMap;
@@ -25,9 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class FlashMapSerializerTest {
 
-    ObjectMapper sut = new ObjectMapper()
-        .registerModule(
-            new SimpleModule().addSerializer(new FlashMapSerializer()));
+    ObjectMapper sut = JsonMapper.builder()
+        .addModule(new SimpleModule().addSerializer(new FlashMapSerializer()))
+        .build();
 
     @Test
     void empty_flash_map_is_serialized() throws Exception {


### PR DESCRIPTION
Spring Boot 4.1.0 ships with Jackson 3.x, which moved its package namespace from com.fasterxml.jackson to tools.jackson and made a few API tweaks along the way. This PR updates spring-cookie to use the new namespace.

Spring Framework has been bumped to 7.0.8 to match what Spring Boot 4.1.0 brings in. Building the library itself now requires JDK 21 or later (which Spring Framework 7.x needs)